### PR TITLE
map common controllers that can be neat-ed

### DIFF
--- a/cmd/neat_test.go
+++ b/cmd/neat_test.go
@@ -93,7 +93,70 @@ func TestNeatMetadata(t *testing.T) {
 	}
 }
 
-func TestNeatPod(t *testing.T) {
+func TestNeatScheduler(t *testing.T) {
+	cases := []struct {
+		title  string
+		data   string
+		expect string
+	}{
+		{
+			title: "nodeName",
+			data: `{
+				"apiVersion": "v1",
+				"kind": "Pod",
+				"metadata": {
+					"name": "myapp",
+					"namespace": "default"
+				},
+				"spec": {
+					"containers": [
+						{
+							"image": "nginx",
+							"imagePullPolicy": "Always",
+							"name": "myapp"
+						}
+					],
+					"nodeName": "minikube"
+				}
+			}`,
+			expect: `{
+				"apiVersion": "v1",
+				"kind": "Pod",
+				"metadata": {
+					"name": "myapp",
+					"namespace": "default"
+				},
+				"spec": {
+					"containers": [
+						{
+							"image": "nginx",
+							"imagePullPolicy": "Always",
+							"name": "myapp"
+						}
+					]
+				}
+			}`,
+		},
+	}
+	for _, c := range cases {
+		resJSON, err := neatScheduler(c.data)
+		if err != nil {
+			t.Errorf("error in neatScheduler for case '%s': %v", c.title, err)
+			continue
+		}
+		equal, err := testutil.JSONEqual(resJSON, c.expect)
+		if err != nil {
+			t.Errorf("error in JSONEqual for case '%s': %v", c.title, err)
+			continue
+		}
+		if !equal {
+			t.Errorf("test case '%s' failed. want: '%s' have: '%s'", c.title, c.expect, resJSON)
+		}
+
+	}
+}
+
+func TestNeatServiceAccount(t *testing.T) {
 	cases := []struct {
 		title  string
 		data   string
@@ -189,9 +252,9 @@ func TestNeatPod(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		resJSON, err := neatPod(c.data)
+		resJSON, err := neatServiceAccount(c.data)
 		if err != nil {
-			t.Errorf("error in neatPod for case '%s': %v", c.title, err)
+			t.Errorf("error in neatServiceAccount for case '%s': %v", c.title, err)
 			continue
 		}
 		equal, err := testutil.JSONEqual(resJSON, c.expect)


### PR DESCRIPTION
In https://github.com/itaysk/kubectl-neat/issues/12 I said that it "might be a good idea to look at admission controllers systematically". This Pr is mapping common controllers as recommended by Kubernetes documentation, and reorganizing the code to neat them instead of just pod specific neat as it was before.