### PR TITLE
fix get subcommand

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,8 +59,8 @@ This mode is invoked by calling the `get` subcommand, i.e `kubectl neat get ...`
 
 Examples:
 ```bash
-kubectl neat get pod mypod -oyaml
-kubectl neat get svc -n default myservice --output json
+kubectl neat get -- pod mypod -oyaml
+kubectl neat get -- svc -n default myservice --output json
 ```
 
 # How it works

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -134,7 +134,7 @@ func TestGetCmd(t *testing.T) {
 		{
 			args: []string{""},
 			assertError: func(err error) bool {
-				return fmt.Sprintf("%T", err) == "*exec.ExitError"
+				return strings.HasPrefix(err.Error(), "Error invoking kubectl")
 			},
 			expOut: "",
 			expErr: "",

--- a/krew-template.yaml
+++ b/krew-template.yaml
@@ -12,7 +12,7 @@ spec:
     removing default values, runtime information, and other internal fields.
     Examples:
     `$ kubectl get pod mypod -o yaml | kubectl neat`
-    `$ kubectl neat get pod mypod -o yaml`
+    `$ kubectl neat get -- pod mypod -o yaml`
   platforms:
     - selector:
         matchLabels:

--- a/test/e2e-krew.bats
+++ b/test/e2e-krew.bats
@@ -14,7 +14,7 @@ function teardown() {
 }
 
 @test "krew install" {
-    run2 kubectl "$plugin" get svc kubernetes -n default
+    run2 kubectl "$plugin" get -- svc kubernetes -n default
     [ "$status" -eq 0 ]
     [ "${stdoutLines[1]}" = "kind: Service" ]
 }

--- a/test/e2e-kubectl.bats
+++ b/test/e2e-kubectl.bats
@@ -18,13 +18,13 @@ function teardown() {
 }
 
 @test "plugin - json" {
-    run2 kubectl "$plugin_name" get -o json svc kubernetes -n default
+    run2 kubectl "$plugin_name" get -o json -- svc kubernetes -n default
     [ "$status" -eq 0 ]
     [[ $stdout == "{"* ]]
 }
 
 @test "plugin - yaml" {
-    run2 kubectl "$plugin_name" get svc kubernetes -n default -o yaml
+    run2 kubectl "$plugin_name" get -- svc kubernetes -n default
     [ "$status" -eq 0 ]
     [[ $stdout == "apiVersion"* ]]
 }


### PR DESCRIPTION
recently released v2 has restructured the "kubectl neat pod ..." functionality in to a cobra subcommand, so it was supposed to become "kubectl neat *get* pod ...". However, this feature didn't work well as it didn't correctly pass the args to kubectl get, and related tests were not great either. The quick fix is to use a `--` to separate the kubectl-neat args from the kubectl get args and allow cobra to function correctly. I may try to look into another solution in the future if people are bothered by this, but for now this is the quickest solution I could come up with.