### PR TITLE
add support for releasing for windows platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,10 @@ jobs:
 
   build:
     name: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
 
       - name: Setup Go
@@ -23,9 +26,11 @@ jobs:
 
       - name: Check gofmt
         run: test -z "$(gofmt -s -d .)"
+        if: matrix.os != 'windows-latest'
       
       - name: Build
         run: make build
+        if: matrix.os != 'windows-latest'
 
       - name: Test
         run: make test-unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,13 @@ jobs:
         run: make build
         if: matrix.os != 'windows-latest'
 
-      - name: Test
+      - name: Unit Test
         run: make test-unit
+
+      - name: Setup BATS for E2E Test
+        uses: mig4/setup-bats@v1
+        with:
+          bats-version: 1.2.1
+
+      - name: E2E Test
+        run: make test-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v1
 
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod              # Module download cache
+            ~/.cache/go-build         # Build cache (Linux)
+            ~/Library/Caches/go-build # Build cache (Mac)
+            '%LocalAppData%\go-build' # Build cache (Windows)
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Check gofmt
         run: test -z "$(gofmt -s -d .)"
         if: matrix.os != 'windows-latest'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,10 +5,14 @@ builds:
   goos:
     - darwin
     - linux
+    - windows
   goarch:
     - amd64
 archives:
 - name_template: "{{ .ProjectName }}_{{ .Os }}"
+  format_overrides:
+    - goos: windows
+      format: zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Makefile
+++ b/Makefile
@@ -14,18 +14,18 @@ test: test-unit test-e2e test-integration
 test-unit:
 	go test -v ./...
 
-test-e2e: dist/kubectl-neat_$(os) 
+test-e2e: dist/kubectl-neat
 	bats ./test/e2e-cli.bats
 
 test-integration: dist/kubectl-neat_$(os).tar.gz dist/kubectl-neat_$(os)*/kubectl-neat dist/checksums.txt
 	bats ./test/e2e-kubectl.bats
 	bats ./test/e2e-krew.bats
 
-build: dist/kubectl-neat_$(os)
+build: dist/kubectl-neat
 
 SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
-dist/kubectl-neat_%: $(SRC)
-	GOOS=$* go build -o dist/$(@F)
+dist/kubectl-neat: $(SRC)
+	go build -o dist/$(@F)
 
 # release by default will not publish. run with `publish=1` to publish
 goreleaserflags = --skip-publish --snapshot

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -125,7 +125,11 @@ func TestRootCmd(t *testing.T) {
 }
 
 func TestGetCmd(t *testing.T) {
-	kubectl = filepath.Join("..", "test", "kubectl-stub")
+	kubectlStub, err := filepath.Abs(filepath.Join("..", "test", "kubectl-stub"))
+	if err != nil {
+		t.Errorf("could not get absolute path to kubectl stub: %v", err)
+	}
+	kubectl = kubectlStub
 	testcases := []struct {
 		args        []string
 		assertError func(err error) bool

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -27,13 +28,13 @@ func assertErrorNil(err error) bool {
 	return err == nil
 }
 func TestRootCmd(t *testing.T) {
-	resourceDataJSONPath := "../test/fixtures/service1-raw.json"
+	resourceDataJSONPath := filepath.Join("..", "test", "fixtures", "service1-raw.json")
 	resourceDataJSONBytes, err := ioutil.ReadFile(resourceDataJSONPath)
 	resourceDataJSON := string(resourceDataJSONBytes)
 	if err != nil {
 		t.Errorf("error readin test data file %s: %v", resourceDataJSONPath, err)
 	}
-	resourceDataYAMLPath := "../test/fixtures/service1-raw.yaml"
+	resourceDataYAMLPath := filepath.Join("..", "test", "fixtures", "service1-raw.yaml")
 	resourceDataYAMLBytes, err := ioutil.ReadFile(resourceDataYAMLPath)
 	resourceDataYAML := string(resourceDataYAMLBytes)
 	if err != nil {
@@ -124,7 +125,7 @@ func TestRootCmd(t *testing.T) {
 }
 
 func TestGetCmd(t *testing.T) {
-	kubectl = "../test/kubectl-stub"
+	kubectl = filepath.Join("..", "test", "kubectl-stub")
 	testcases := []struct {
 		args        []string
 		assertError func(err error) bool

--- a/cmd/neat_test.go
+++ b/cmd/neat_test.go
@@ -323,7 +323,7 @@ func TestNeatEmpty(t *testing.T) {
 }
 
 func TestNeat(t *testing.T) {
-	testsDir := "../test/fixtures"
+	testsDir := filepath.Join("..", "test", "fixtures")
 	testFiles, err := ioutil.ReadDir(testsDir)
 	if err != nil {
 		t.Fatalf("can't list tests in: %s", testsDir)

--- a/test/e2e-cli.bats
+++ b/test/e2e-cli.bats
@@ -1,7 +1,6 @@
 #!/usr/bin/env bats
 load bats-workaround
-runtime_os=$(uname -s | tr '[:upper:]' '[:lower:]') 
-exe="dist/kubectl-neat_${runtime_os}"
+exe="dist/kubectl-neat"
 rootDir="./test/fixtures"
 
 @test "invalid args 1" {


### PR DESCRIPTION
fixes #6 

- [x] Build for windows
- [x] Zip format for windows archive artifact - I see that zip is pretty usual thing in windows. If you don't feel so, we can change it. Reference - [goreleaser releases](https://github.com/goreleaser/goreleaser/releases), [helm releases](https://github.com/helm/helm/releases/)
- [ ] Run Tests on windows environment
- [ ] Add windows platform in the krew template yaml
- [ ] Make changes to Makefile - release and dist/* targets - invoke krew package script for windows too . Merge windows too from the list of JSON files