### PR TITLE
Fix test for Go 1.16

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -17,8 +17,8 @@ package cmd
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 )
@@ -74,7 +74,8 @@ func TestRootCmd(t *testing.T) {
 			args:  []string{"-f", "/nogood"},
 			stdin: "",
 			assertError: func(err error) bool {
-				return fmt.Sprintf("%T", err) == "*os.PathError"
+				_, ok := err.(*os.PathError)
+				return ok
 			},
 			expOut: "",
 		},


### PR DESCRIPTION
TestRootCmd fails because of os.PathError changes introduced in Go 1.16. Although it is still the expected type (alias to fs.PathError), `%T` in Sprintf prints something else.

```
cmd_test.go:115: error assertion: have: &fs.PathError{Op:"open", Path:"/nogood", Err:0x2}
    test case: {[-f /nogood]  0x55adcb95a800 }
```