### PR TITLE
chore: upgrade to golang 1.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.12
+          go-version: 1.17
         id: go
 
       - name: Check out code

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/itaysk/kubectl-neat
 
-go 1.12
+go 1.17
 
 require (
 	github.com/ghodss/yaml v1.0.0
@@ -12,6 +12,30 @@ require (
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0
 	k8s.io/kubernetes v1.17.0
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d // indirect
+	github.com/google/gofuzz v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.8 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tidwall/match v1.0.1 // indirect
+	github.com/tidwall/pretty v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 // indirect
+	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.2.4 // indirect
+	k8s.io/api v0.17.0 // indirect
+	k8s.io/apiextensions-apiserver v0.0.0 // indirect
+	k8s.io/apiserver v0.17.0 // indirect
+	k8s.io/component-base v0.17.0 // indirect
+	k8s.io/klog v1.0.0 // indirect
+	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f // indirect
+	sigs.k8s.io/yaml v1.1.0 // indirect
 )
 
 replace (


### PR DESCRIPTION
Run CI with the latest stable version 1.17.
Related to #75 