### PR TITLE
Remove list metadata for parent object

### DIFF
--- a/cmd/neat.go
+++ b/cmd/neat.go
@@ -52,6 +52,11 @@ func Neat(in string) (string, error) {
 				continue
 			}
 		}
+		// general neating
+		draft, err = neatMetadata(draft)
+		if err != nil {
+			return draft, fmt.Errorf("error in neatMetadata : %v", err)
+		}
 		return draft, nil
 	}
 

--- a/test/fixtures/list1-neat.json
+++ b/test/fixtures/list1-neat.json
@@ -74,7 +74,5 @@
     ],
     "kind": "List",
     "metadata": {
-        "resourceVersion": "",
-        "selfLink": ""
     }
 }


### PR DESCRIPTION
As per #68. Removed the "resourceVersion" and "selfLink" from the k8s list test fixture. Call 'neatMetadata' before returning from 'Neat' function so it is applied to the list object.