### PR TITLE
change bash shebangs to be more portable

### DIFF
--- a/hack/update-kubernetes-deps.sh
+++ b/hack/update-kubernetes-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VERSION=${1#"v"}
 if [ -z "$VERSION" ]; then

--- a/krew-package.sh
+++ b/krew-package.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 # This script makes a platform specific krew package
 # it assumes goreleaser had already run and created the archives and the checksums
 # Arguments:

--- a/test/kubectl-stub
+++ b/test/kubectl-stub
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # based on Argbash: https://argbash.io
 


### PR DESCRIPTION
When running kubectl-neat tests on a nixos system, I was getting test failures like the following:

```
--- FAIL: TestGetCmd (0.00s)
    cmd_test.go:186: error assertion: have: &errors.errorString{s:"Error invoking kubectl as [../test/kubectl-stub get -o json pods] fork/exec ../test/kubectl-stub:
 no such file or directory"}
        test case: {[pods] 0x1021740 apiVersion }
```

And running the script directly:

```
$ ./test/kubectl-stub
zsh: ./test/kubectl-stub: bad interpreter: /bin/bash: no such file or directory
```

This PR changes the shebang to `#!/usr/bin/env bash` to make the tests more portable across systems. I changed the other bash shebangs for good measure.