### PR TITLE
fix issue while neating multi yaml documents (issue #109)

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -39,7 +39,12 @@ func TestRootCmd(t *testing.T) {
 	if err != nil {
 		t.Errorf("error readin test data file %s: %v", resourceDataYAMLPath, err)
 	}
-
+	resourceDataMultiYAMLPath := "../test/fixtures/multidoc-raw.yaml"
+	resourceDataMultiYAMLBytes, err := ioutil.ReadFile(resourceDataMultiYAMLPath)
+	resourceDataMultiYAML := string(resourceDataMultiYAMLBytes)
+	if err != nil {
+		t.Errorf("error readin test data file %s: %v", resourceDataMultiYAMLPath, err)
+	}
 	testcases := []struct {
 		args        []string
 		stdin       string
@@ -65,6 +70,12 @@ func TestRootCmd(t *testing.T) {
 			expOut:      "apiVersion",
 		},
 		{
+			args:        []string{},
+			stdin:       resourceDataMultiYAML,
+			assertError: assertErrorNil,
+			expOut:      "apiVersion",
+		},
+		{
 			args:        []string{"-f", "-"},
 			stdin:       resourceDataJSON,
 			assertError: assertErrorNil,
@@ -81,6 +92,12 @@ func TestRootCmd(t *testing.T) {
 		},
 		{
 			args:        []string{"-f", resourceDataJSONPath},
+			stdin:       "",
+			assertError: assertErrorNil,
+			expOut:      "apiVersion",
+		},
+		{
+			args:        []string{"-f", resourceDataMultiYAMLPath},
 			stdin:       "",
 			assertError: assertErrorNil,
 			expOut:      "apiVersion",

--- a/test/fixtures/multidoc-raw.yaml
+++ b/test/fixtures/multidoc-raw.yaml
@@ -1,0 +1,159 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJteXJlZ2lzdHJ5LnRlc3QiOnsidXNlcm5hbWUiOiJ1c2VyIiwicGFzc3dvcmQiOiJwYXNzIiwiZW1haWwiOiJ1c2VyQGVtYWlsLnRlc3QiLCJhdXRoIjoiZFhObGNqcHdZWE56In19fQ==
+kind: Secret
+metadata:
+  creationTimestamp: "2020-04-03T05:45:54Z"
+  name: myreg
+  namespace: default
+  resourceVersion: "3376"
+  selfLink: /api/v1/namespaces/default/secrets/myreg
+  uid: 62a187fd-756e-11ea-b27b-0242ac11002d
+type: kubernetes.io/dockerconfigjson
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2019-04-24T20:12:14Z"
+  name: myappservice
+  namespace: default
+  resourceVersion: "187503"
+  selfLink: /api/v1/namespaces/default/services/myappservice
+  uid: 409de7fb-66cd-11e9-b6fa-0800271788ca
+spec:
+  clusterIP: None
+  ports:
+  - port: 2222
+    protocol: TCP
+    targetPort: 2222
+  selector:
+    name: myapp
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+    hostPathProvisionerIdentity: 7de69121-4d7a-11e9-8684-0800271788ca
+    pv.kubernetes.io/provisioned-by: k8s.io/minikube-hostpath
+  creationTimestamp: "2019-03-23T14:52:51Z"
+  finalizers:
+  - kubernetes.io/pv-protection
+  name: pvc-54fad2fe-4d7b-11e9-9172-0800271788ca
+  resourceVersion: "186863"
+  selfLink: /api/v1/persistentvolumes/pvc-54fad2fe-4d7b-11e9-9172-0800271788ca
+  uid: 5527dbad-4d7b-11e9-9172-0800271788ca
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 2Gi
+  claimRef:
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: prom-prometheus-alertmanager
+    namespace: default
+    resourceVersion: "860"
+    uid: 54fad2fe-4d7b-11e9-9172-0800271788ca
+  hostPath:
+    path: /tmp/hostpath-provisioner/pvc-54fad2fe-4d7b-11e9-9172-0800271788ca
+    type: ""
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: standard
+  volumeMode: Filesystem
+status:
+  phase: Released
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2019-04-24T19:55:27Z"
+  labels:
+    name: myapp
+  name: myapp
+  namespace: default
+  resourceVersion: "274103"
+  selfLink: /api/v1/namespaces/default/pods/myapp
+  uid: e8330f3c-66ca-11e9-b6fa-0800271788ca
+spec:
+  containers:
+  - image: nginx
+    imagePullPolicy: Always
+    name: myapp
+    ports:
+    - containerPort: 1234
+      protocol: TCP
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-nmshj
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: minikube
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - name: default-token-nmshj
+    secret:
+      defaultMode: 420
+      secretName: default-token-nmshj
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2019-04-24T19:55:27Z"
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2019-07-06T18:41:25Z"
+    status: "True"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2019-07-06T18:41:25Z"
+    status: "True"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2019-04-24T19:55:27Z"
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: docker://92d7dc7a851453c2f1e75c4af42a9e72fea50127fede62dfbd5fbb6fb0481fcc
+    image: nginx:latest
+    imageID: docker-pullable://nginx@sha256:96fb261b66270b900ea5a2c17a26abbfabe95506e73c3a3c65869a6dbe83223a
+    lastState:
+      terminated:
+        containerID: docker://288fc0a2b98708d6a4661f59c54c4ae366c1acea642f000ba9615932dbff411f
+        exitCode: 0
+        finishedAt: "2019-07-04T08:17:20Z"
+        reason: Completed
+        startedAt: "2019-07-03T05:55:39Z"
+    name: myapp
+    ready: true
+    restartCount: 3
+    state:
+      running:
+        startedAt: "2019-07-06T18:41:25Z"
+  hostIP: 10.0.2.15
+  phase: Running
+  podIP: 172.17.0.2
+  qosClass: BestEffort
+  startTime: "2019-04-24T19:55:27Z"


### PR DESCRIPTION
This PR addresses issue #109 by adding logic to handle multiple dash-separated raw YAML files, allowing them to be processed in a single command. For testing, I created a merged YAML file (based on the existing test files) and used it in two test cases within cmd_test.go. The new feature works for both outputs(json and yaml)